### PR TITLE
Added support for custom item shapes

### DIFF
--- a/lib/salomon_bottom_bar.dart
+++ b/lib/salomon_bottom_bar.dart
@@ -12,6 +12,7 @@ class SalomonBottomBar extends StatelessWidget {
     this.selectedItemColor,
     this.unselectedItemColor,
     this.selectedColorOpacity,
+    this.itemShape = const StadiumBorder(),
     this.margin = const EdgeInsets.all(8),
     this.itemPadding = const EdgeInsets.symmetric(vertical: 10, horizontal: 16),
     this.duration = const Duration(milliseconds: 500),
@@ -35,6 +36,9 @@ class SalomonBottomBar extends StatelessWidget {
 
   /// The opacity of color of the touchable background when the item is selected.
   final double? selectedColorOpacity;
+
+  /// The border shape of each item.
+  final ShapeBorder itemShape;
 
   /// A convenience field for the margin surrounding the entire widget.
   final EdgeInsets margin;
@@ -73,15 +77,17 @@ class SalomonBottomBar extends StatelessWidget {
                     unselectedItemColor ??
                     theme.iconTheme.color;
 
+                final _itemShape = item.shape ?? itemShape;
+
                 return Material(
                   color: Color.lerp(
                       _selectedColor.withOpacity(0.0),
                       _selectedColor.withOpacity(selectedColorOpacity ?? 0.1),
                       t),
-                  shape: StadiumBorder(),
+                  shape: _itemShape,
                   child: InkWell(
                     onTap: () => onTap?.call(items.indexOf(item)),
-                    customBorder: StadiumBorder(),
+                    customBorder: _itemShape,
                     focusColor: _selectedColor.withOpacity(0.1),
                     highlightColor: _selectedColor.withOpacity(0.1),
                     splashColor: _selectedColor.withOpacity(0.1),
@@ -153,6 +159,9 @@ class SalomonBottomBarItem {
   /// Text to display, ie `Home`
   final Widget title;
 
+  /// The shape of this item.
+  final ShapeBorder? shape;
+
   /// A primary color to use for this tab.
   final Color? selectedColor;
 
@@ -162,6 +171,7 @@ class SalomonBottomBarItem {
   SalomonBottomBarItem({
     required this.icon,
     required this.title,
+    this.shape,
     this.selectedColor,
     this.unselectedColor,
     this.activeIcon,

--- a/lib/salomon_bottom_bar.dart
+++ b/lib/salomon_bottom_bar.dart
@@ -77,17 +77,15 @@ class SalomonBottomBar extends StatelessWidget {
                     unselectedItemColor ??
                     theme.iconTheme.color;
 
-                final _itemShape = item.shape ?? itemShape;
-
                 return Material(
                   color: Color.lerp(
                       _selectedColor.withOpacity(0.0),
                       _selectedColor.withOpacity(selectedColorOpacity ?? 0.1),
                       t),
-                  shape: _itemShape,
+                  shape: itemShape,
                   child: InkWell(
                     onTap: () => onTap?.call(items.indexOf(item)),
-                    customBorder: _itemShape,
+                    customBorder: itemShape,
                     focusColor: _selectedColor.withOpacity(0.1),
                     highlightColor: _selectedColor.withOpacity(0.1),
                     splashColor: _selectedColor.withOpacity(0.1),
@@ -159,9 +157,6 @@ class SalomonBottomBarItem {
   /// Text to display, ie `Home`
   final Widget title;
 
-  /// The shape of this item.
-  final ShapeBorder? shape;
-
   /// A primary color to use for this tab.
   final Color? selectedColor;
 
@@ -171,7 +166,6 @@ class SalomonBottomBarItem {
   SalomonBottomBarItem({
     required this.icon,
     required this.title,
-    this.shape,
     this.selectedColor,
     this.unselectedColor,
     this.activeIcon,


### PR DESCRIPTION
This PR adds support for custom item shapes other than just StadiumBorder.
It can be specified per item or for all items. Mimicking the behaviour of the other parameters, the shape specified on each item takes priority over the shape defined for that BottomBar.

Example shape could be
```dart
RoundedRectangleBorder(
  borderRadius: BorderRadius.circular(10)
)
```