### PR TITLE
Spacing `SalomonBottomBarItem` evenly when there are 2 or less.

### DIFF
--- a/lib/salomon_bottom_bar.dart
+++ b/lib/salomon_bottom_bar.dart
@@ -59,7 +59,11 @@ class SalomonBottomBar extends StatelessWidget {
     return Padding(
       padding: margin,
       child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        /// Using a different alignment when there are 2 items or less
+        /// so it behaves the same as BottomNavigationBar.
+        mainAxisAlignment: items.length <= 2
+            ? MainAxisAlignment.spaceEvenly
+            : MainAxisAlignment.spaceBetween,
         children: [
           for (final item in items)
             TweenAnimationBuilder<double>(


### PR DESCRIPTION
## Previous behavior 
![image](https://user-images.githubusercontent.com/26900172/155760837-6918c7cb-3154-4494-9c79-af691bb73236.png)
![155700697-6606164d-4835-430e-b0bb-07eccd36407a](https://user-images.githubusercontent.com/26900172/155760767-30cee716-8bd7-43f9-a851-949a2a9edb4f.png)

## New behavior
![image](https://user-images.githubusercontent.com/26900172/155760897-0a92a3be-838b-4160-bf23-77f16e1394e6.png)
![image](https://user-images.githubusercontent.com/26900172/155760904-e25d169a-3251-42bc-a988-77b43ea3b24f.png)

