### PR TITLE
`alignment` support

### DIFF
--- a/lib/salomon_bottom_bar.dart
+++ b/lib/salomon_bottom_bar.dart
@@ -17,6 +17,7 @@ class SalomonBottomBar extends StatelessWidget {
     this.itemPadding = const EdgeInsets.symmetric(vertical: 10, horizontal: 16),
     this.duration = const Duration(milliseconds: 500),
     this.curve = Curves.easeOutQuint,
+    this.mainAxisAlignment = MainAxisAlignment.spaceBetween,
   }) : super(key: key);
 
   /// A list of tabs to display, ie `Home`, `Likes`, etc
@@ -52,6 +53,9 @@ class SalomonBottomBar extends StatelessWidget {
   /// The transition curve
   final Curve curve;
 
+  /// Horizontal alignment of items
+  final MainAxisAlignment mainAxisAlignment;
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -63,7 +67,7 @@ class SalomonBottomBar extends StatelessWidget {
         /// so it behaves the same as BottomNavigationBar.
         mainAxisAlignment: items.length <= 2
             ? MainAxisAlignment.spaceEvenly
-            : MainAxisAlignment.spaceBetween,
+            : mainAxisAlignment,
         children: [
           for (final item in items)
             TweenAnimationBuilder<double>(


### PR DESCRIPTION
### Problem
- While working on a project with `salomon_bottom_bar` package, I had to change the `alignment` of the elements. I made ad-hoc changes locally.

### Solution
- Let the user pass the `mainAxisAlignment`.
  - The given value will affect only if the length > 2
  - If not given, the default value will affect, i.e. `spaceBetween`

- Though I'm not sure if it comes under the planned features of the package, I submit a PR.
