### PR TITLE
Feature/49 add box shadow

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Flutter VM",
+      "cwd": "example",
+      "request": "launch",
+      "type": "dart"
+    },
+    {
+      "name": "Flutter Web",
+      "cwd": "example",
+      "request": "launch",
+      "type": "dart",
+      "args": ["-d", "chrome"]
+    },
+  ]
+}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
@@ -37,18 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
-  cupertino_icons:
-    dependency: "direct main"
-    description:
-      name: cupertino_icons
-      sha256: a937da4c006989739ceb4d10e3bd6cce64ca85d0fe287fc5b2b9f6ee757dcee6
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.3"
+    version: "1.18.0"
   fake_async:
     dependency: transitive
     description:
@@ -67,46 +59,62 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  js:
+  leak_tracker:
     dependency: transitive
     description:
-      name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.11.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   salomon_bottom_bar:
     dependency: "direct main"
     description:
@@ -123,26 +131,26 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -163,10 +171,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.6.1"
   vector_math:
     dependency: transitive
     description:
@@ -175,5 +183,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.0"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=3.3.0 <4.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,7 +10,6 @@ dependencies:
   flutter:
     sdk: flutter
 
-  cupertino_icons: ^0.1.3
   salomon_bottom_bar:
     path: ../
 

--- a/lib/salomon_bottom_bar.dart
+++ b/lib/salomon_bottom_bar.dart
@@ -14,6 +14,7 @@ class SalomonBottomBar extends StatelessWidget {
     this.unselectedItemColor,
     this.selectedColorOpacity,
     this.itemShape = const StadiumBorder(),
+    this.itemDecoration,
     this.margin = const EdgeInsets.all(8),
     this.itemPadding = const EdgeInsets.symmetric(vertical: 10, horizontal: 16),
     this.duration = const Duration(milliseconds: 500),
@@ -43,6 +44,9 @@ class SalomonBottomBar extends StatelessWidget {
 
   /// The border shape of each item.
   final ShapeBorder itemShape;
+
+  /// The decoration of each item.
+  final SalomonItemDecoration? itemDecoration;
 
   /// A convenience field for the margin surrounding the entire widget.
   final EdgeInsets margin;
@@ -79,6 +83,8 @@ class SalomonBottomBar extends StatelessWidget {
                 curve: curve,
                 duration: duration,
                 builder: (context, t, _) {
+                  final isSelected = items.indexOf(item) == currentIndex;
+
                   final _selectedColor = item.selectedColor ??
                       selectedItemColor ??
                       theme.primaryColor;
@@ -87,71 +93,88 @@ class SalomonBottomBar extends StatelessWidget {
                       unselectedItemColor ??
                       theme.iconTheme.color;
 
-                  return Material(
-                    color: Color.lerp(
-                        _selectedColor.withOpacity(0.0),
-                        _selectedColor.withOpacity(selectedColorOpacity ?? 0.1),
-                        t),
-                    shape: itemShape,
-                    child: InkWell(
-                      onTap: () => onTap?.call(items.indexOf(item)),
-                      customBorder: itemShape,
-                      focusColor: _selectedColor.withOpacity(0.1),
-                      highlightColor: _selectedColor.withOpacity(0.1),
-                      splashColor: _selectedColor.withOpacity(0.1),
-                      hoverColor: _selectedColor.withOpacity(0.1),
-                      child: Padding(
-                        padding: itemPadding -
-                            (Directionality.of(context) == TextDirection.ltr
-                                ? EdgeInsets.only(right: itemPadding.right * t)
-                                : EdgeInsets.only(left: itemPadding.left * t)),
-                        child: Row(
-                          children: [
-                            IconTheme(
-                              data: IconThemeData(
-                                color: Color.lerp(
-                                    _unselectedColor, _selectedColor, t),
-                                size: 24,
+                  final _selectedBoxShadow = item.selectedBoxShadow ??
+                      itemDecoration?.selectedBoxShadow ??
+                      null;
+
+                  final _unselectedBoxShadow = item.unselectedBoxShadow ??
+                      itemDecoration?.unselectedBoxShadow ??
+                      null;
+
+                  return Container(
+                    decoration: (itemDecoration != null ||
+                            item.selectedBoxShadow != null ||
+                            item.unselectedBoxShadow != null)
+                        ? BoxDecoration(
+                            boxShadow: isSelected
+                                ? _selectedBoxShadow
+                                : _unselectedBoxShadow,
+                          )
+                        : null,
+                    child: Material(
+                      shape: itemShape,
+                      child: InkWell(
+                        onTap: () => onTap?.call(items.indexOf(item)),
+                        customBorder: itemShape,
+                        focusColor: _selectedColor.withOpacity(0.1),
+                        highlightColor: _selectedColor.withOpacity(0.1),
+                        splashColor: _selectedColor.withOpacity(0.1),
+                        hoverColor: _selectedColor.withOpacity(0.1),
+                        child: Padding(
+                          padding: itemPadding -
+                              (Directionality.of(context) == TextDirection.ltr
+                                  ? EdgeInsets.only(
+                                      right: itemPadding.right * t)
+                                  : EdgeInsets.only(
+                                      left: itemPadding.left * t)),
+                          child: Row(
+                            children: [
+                              IconTheme(
+                                data: IconThemeData(
+                                  color: Color.lerp(
+                                      _unselectedColor, _selectedColor, t),
+                                  size: 24,
+                                ),
+                                child: items.indexOf(item) == currentIndex
+                                    ? item.activeIcon ?? item.icon
+                                    : item.icon,
                               ),
-                              child: items.indexOf(item) == currentIndex
-                                  ? item.activeIcon ?? item.icon
-                                  : item.icon,
-                            ),
-                            ClipRect(
-                              clipBehavior: Clip.antiAlias,
-                              child: SizedBox(
-                                /// TODO: Constrain item height without a fixed value
-                                ///
-                                /// The Align property appears to make these full height, would be
-                                /// best to find a way to make it respond only to padding.
-                                height: 20,
-                                child: Align(
-                                  alignment: Alignment(-0.2, 0.0),
-                                  widthFactor: t,
-                                  child: Padding(
-                                    padding: Directionality.of(context) ==
-                                            TextDirection.ltr
-                                        ? EdgeInsets.only(
-                                            left: itemPadding.left / 2,
-                                            right: itemPadding.right)
-                                        : EdgeInsets.only(
-                                            left: itemPadding.left,
-                                            right: itemPadding.right / 2),
-                                    child: DefaultTextStyle(
-                                      style: TextStyle(
-                                        color: Color.lerp(
-                                            _selectedColor.withOpacity(0.0),
-                                            _selectedColor,
-                                            t),
-                                        fontWeight: FontWeight.w600,
+                              ClipRect(
+                                clipBehavior: Clip.antiAlias,
+                                child: SizedBox(
+                                  /// TODO: Constrain item height without a fixed value
+                                  ///
+                                  /// The Align property appears to make these full height, would be
+                                  /// best to find a way to make it respond only to padding.
+                                  height: 20,
+                                  child: Align(
+                                    alignment: Alignment(-0.2, 0.0),
+                                    widthFactor: t,
+                                    child: Padding(
+                                      padding: Directionality.of(context) ==
+                                              TextDirection.ltr
+                                          ? EdgeInsets.only(
+                                              left: itemPadding.left / 2,
+                                              right: itemPadding.right)
+                                          : EdgeInsets.only(
+                                              left: itemPadding.left,
+                                              right: itemPadding.right / 2),
+                                      child: DefaultTextStyle(
+                                        style: TextStyle(
+                                          color: Color.lerp(
+                                              _selectedColor.withOpacity(0.0),
+                                              _selectedColor,
+                                              t),
+                                          fontWeight: FontWeight.w600,
+                                        ),
+                                        child: item.title,
                                       ),
-                                      child: item.title,
                                     ),
                                   ),
                                 ),
                               ),
-                            ),
-                          ],
+                            ],
+                          ),
                         ),
                       ),
                     ),
@@ -182,11 +205,78 @@ class SalomonBottomBarItem {
   /// The color to display when this tab is not selected.
   final Color? unselectedColor;
 
+  /// You can override each items boxShadow with this property
+  ///
+  /// A list of shadows cast by this box behind the box (when selected).
+  ///
+  /// The shadow follows the [shape] of the box.
+  ///
+  /// See also:
+  ///
+  ///  * [kElevationToShadow], for some predefined shadows used in Material
+  ///    Design.
+  ///  * [PhysicalModel], a widget for showing shadows.
+  final List<BoxShadow>? selectedBoxShadow;
+
+  /// You can override each items boxShadow with this property
+  ///
+  /// A list of shadows cast by this box behind the box (when not selected).
+  ///
+  /// The shadow follows the [shape] of the box.
+  ///
+  /// See also:
+  ///
+  ///  * [kElevationToShadow], for some predefined shadows used in Material
+  ///    Design.
+  ///  * [PhysicalModel], a widget for showing shadows.
+  final List<BoxShadow>? unselectedBoxShadow;
+
   SalomonBottomBarItem({
     required this.icon,
     required this.title,
     this.selectedColor,
     this.unselectedColor,
     this.activeIcon,
+    this.selectedBoxShadow,
+    this.unselectedBoxShadow,
   });
+}
+
+/// A controlled [Decoration] for each [SalomonBottomBarItem]
+class SalomonItemDecoration {
+  /// A list of shadows cast by this box behind the box (when selected).
+  ///
+  /// The shadow follows the [shape] of the box.
+  ///
+  /// See also:
+  ///
+  ///  * [kElevationToShadow], for some predefined shadows used in Material
+  ///    Design.
+  ///  * [PhysicalModel], a widget for showing shadows.
+  final List<BoxShadow>? selectedBoxShadow;
+
+  /// A list of shadows cast by this box behind the box (when not selected).
+  ///
+  /// The shadow follows the [shape] of the box.
+  ///
+  /// See also:
+  ///
+  ///  * [kElevationToShadow], for some predefined shadows used in Material
+  ///    Design.
+  ///  * [PhysicalModel], a widget for showing shadows.
+  final List<BoxShadow>? unselectedBoxShadow;
+
+  const SalomonItemDecoration({
+    this.selectedBoxShadow,
+    this.unselectedBoxShadow,
+  });
+
+  SalomonItemDecoration copyWith({
+    List<BoxShadow>? selectedBoxShadow,
+    List<BoxShadow>? unselectedBoxShadow,
+  }) =>
+      SalomonItemDecoration(
+        selectedBoxShadow: selectedBoxShadow ?? this.selectedBoxShadow,
+        unselectedBoxShadow: unselectedBoxShadow ?? this.unselectedBoxShadow,
+      );
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   fake_async:
     dependency: transitive
     description:
@@ -59,46 +59,62 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  js:
+  leak_tracker:
     dependency: transitive
     description:
-      name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.11.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -108,26 +124,26 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -148,10 +164,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.6.1"
   vector_math:
     dependency: transitive
     description:
@@ -160,5 +176,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.0"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=3.3.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 3.3.2
 homepage: https://github.com/lukepighetti/salomon_bottom_bar
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=3.3.0 <4.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Related Issues

- https://github.com/lukepighetti/salomon_bottom_bar/issues/49

## Context

This PR adds both `SalomonItemDecoration` as a global `Decoration` for each selected and unselected Items and also add boxShadow overrides for each item, so that users can control globally as seperatly the boxShadow.

I decided to create a **controlled** DataClass `SalomonItemDecoration` instead of Flutter's `Decoration` so users can't misuse the supported Decorations.

## Example:

**Global**:

```dart
bottomNavigationBar: SalomonBottomBar(
          itemDecoration: SalomonItemDecoration(
            selectedBoxShadow: [
              BoxShadow(
                color: Colors.blue.withOpacity(.5),
                blurRadius: 25,
              ),
            ],
          ),
          ...
```

**In each item**:

```dart
items: [
            /// Home
            SalomonBottomBarItem(
              icon: Icon(Icons.home),
              title: Text("Home"),
              selectedColor: Colors.purple,
              selectedBoxShadow: [
                BoxShadow(
                  color: Colors.red.withOpacity(1),
                  blurRadius: 20,
                ),
              ],
            ),
          ...
```

@lukepighetti @imaNNeo please review this if you got time.