### PR TITLE
Remove menu item's splash animation by parameter

### DIFF
--- a/lib/salomon_bottom_bar.dart
+++ b/lib/salomon_bottom_bar.dart
@@ -18,6 +18,7 @@ class SalomonBottomBar extends StatelessWidget {
     this.itemPadding = const EdgeInsets.symmetric(vertical: 10, horizontal: 16),
     this.duration = const Duration(milliseconds: 500),
     this.curve = Curves.easeOutQuint,
+    this.splashActive = true,
   }) : super(key: key);
 
   /// A list of tabs to display, ie `Home`, `Likes`, etc
@@ -55,6 +56,9 @@ class SalomonBottomBar extends StatelessWidget {
 
   /// The transition curve
   final Curve curve;
+
+  /// The splash animastion is active 
+  final bool flashActive;
 
   @override
   Widget build(BuildContext context) {
@@ -98,7 +102,7 @@ class SalomonBottomBar extends StatelessWidget {
                       customBorder: itemShape,
                       focusColor: _selectedColor.withOpacity(0.1),
                       highlightColor: _selectedColor.withOpacity(0.1),
-                      splashColor: Colors.transparent,
+                      splashColor: flashActive ? _selectedColor.withOpacity(0.1) : Colors.transparent,
                       hoverColor: _selectedColor.withOpacity(0.1),
                       child: Padding(
                         padding: itemPadding -

--- a/lib/salomon_bottom_bar.dart
+++ b/lib/salomon_bottom_bar.dart
@@ -98,7 +98,7 @@ class SalomonBottomBar extends StatelessWidget {
                       customBorder: itemShape,
                       focusColor: _selectedColor.withOpacity(0.1),
                       highlightColor: _selectedColor.withOpacity(0.1),
-                      splashColor: _selectedColor.withOpacity(0.1),
+                      splashColor: Colors.transparent,
                       hoverColor: _selectedColor.withOpacity(0.1),
                       child: Padding(
                         padding: itemPadding -

--- a/lib/salomon_bottom_bar.dart
+++ b/lib/salomon_bottom_bar.dart
@@ -102,7 +102,7 @@ class SalomonBottomBar extends StatelessWidget {
                       customBorder: itemShape,
                       focusColor: _selectedColor.withOpacity(0.1),
                       highlightColor: _selectedColor.withOpacity(0.1),
-                      splashColor: flashActive ? _selectedColor.withOpacity(0.1) : Colors.transparent,
+                      splashColor: splashActive ? _selectedColor.withOpacity(0.1) : Colors.transparent,
                       hoverColor: _selectedColor.withOpacity(0.1),
                       child: Padding(
                         padding: itemPadding -

--- a/lib/salomon_bottom_bar.dart
+++ b/lib/salomon_bottom_bar.dart
@@ -58,7 +58,7 @@ class SalomonBottomBar extends StatelessWidget {
   final Curve curve;
 
   /// The splash animastion is active 
-  final bool flashActive;
+  final bool splashActive;
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
I added a new basic feature to remove splash animation. Now when you click, menu button doesn't give any feedback.


You can do this with set `splashActive` parameter to `false`. Default is `true`.